### PR TITLE
Update progress.ts

### DIFF
--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -1,8 +1,8 @@
 import Gauge from 'gauge';
 
 interface Progress {
-	progress(text: string, bytes: number): void;
-	pulse(name: string): void;
+	progress: (text: string, bytes: number) => void;
+	pulse: (name: string) => void;
 }
 
 export default (): Progress => {


### PR DESCRIPTION
use arrow function to avoid unbounded reference to this error.([reference](https://stackoverflow.com/questions/62864908/how-to-prevent-typescript-eslint-unbound-method-errors-on-non-class-typescrip))