### PR TITLE
feat: added flag --delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5705,7 +5705,11 @@
 		},
 		"metacall-protocol": {
 			"version": "git+ssh://git@github.com/metacall/protocol.git#3562dcf513b864b668715d9ee0465fadc727b671",
+<<<<<<< Updated upstream
 			"from": "metacall-protocol@github:metacall/protocol",
+=======
+			"from": "metacall-protocol@https://github.com/metacall/protocol",
+>>>>>>> Stashed changes
 			"requires": {
 				"axios": "^0.21.0",
 				"form-data": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5705,11 +5705,7 @@
 		},
 		"metacall-protocol": {
 			"version": "git+ssh://git@github.com/metacall/protocol.git#3562dcf513b864b668715d9ee0465fadc727b671",
-<<<<<<< Updated upstream
 			"from": "metacall-protocol@github:metacall/protocol",
-=======
-			"from": "metacall-protocol@https://github.com/metacall/protocol",
->>>>>>> Stashed changes
 			"requires": {
 				"axios": "^0.21.0",
 				"form-data": "^3.0.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -12,7 +12,8 @@ const cliArgsDescription: { [k: string]: string } = {
 	token: 'accepts token for authentication, either pass email & password or token.',
 	force: 'accepts boolean value : it deletes the deployment present on an existing plan and deploys again.',
 	plan: 'accepts type of plan : "Essential", "Standard", "Premium".',
-	inspect: 'lists out all the deployments with specifications'
+	inspect: 'lists out all the deployments with specifications',
+	delete: 'accepts boolean value: it provides you all the available deployment options to delete'
 };
 
 interface CLIArgs {
@@ -27,6 +28,7 @@ interface CLIArgs {
 	plan?: Plans;
 	confDir?: string;
 	inspect?: boolean;
+	delete?: boolean;
 }
 
 const parsePlan = (planType: string): Plans | undefined => {
@@ -98,6 +100,13 @@ export default parse<CLIArgs>(
 			defaultValue: false,
 			optional: true,
 			description: cliArgsDescription.inspect
+		},
+		delete: {
+			type: Boolean,
+			alias: 'D',
+			defaultValue: false,
+			optional: true,
+			description: cliArgsDescription.delete
 		},
 		confDir: { type: String, alias: 'd', optional: true }
 	},

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -50,12 +50,15 @@ export const planSelection = (message: string): Promise<Plans> =>
 		}
 	]).then((res: { plan: Plans }) => res.plan);
 
-export const containerSelection = (containers: string[]): Promise<string> =>
+export const listSelection = (
+	list: string[],
+	message: string
+): Promise<string> =>
 	prompt<{ container: string }>([
 		{
 			type: 'list',
 			name: 'container',
-			message: 'Select a container to get logs',
-			choices: containers
+			message,
+			choices: list
 		}
 	]).then((res: { container: string }) => res.container);

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from 'axios';
+import API from 'metacall-protocol/protocol';
+import { apiError, info } from './cli/messages';
+import { startup } from './startup';
+
+export const del = async (
+	prefix: string,
+	suffix: string,
+	version: string
+): Promise<void> => {
+	const config = await startup();
+	const api = API(config.token as string, config.baseURL);
+
+	try {
+		info(await api.deployDelete(prefix, suffix, version));
+	} catch (err) {
+		apiError(err as AxiosError);
+	}
+};

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -17,9 +17,9 @@ import { input } from './cli/inputs';
 import { apiError, error, info, printLanguage, warn } from './cli/messages';
 import Progress from './cli/progress';
 import {
-	containerSelection,
 	fileSelection,
-	languageSelection
+	languageSelection,
+	listSelection
 } from './cli/selection';
 import { Config } from './config';
 import { logs } from './logs';
@@ -107,10 +107,10 @@ export const deployPackage = async (
 			// TODO: Need a TUI for logs
 
 			try {
-				const container: string = await containerSelection([
-					...descriptor.runners,
-					'deploy'
-				]);
+				const container: string = await listSelection(
+					[...descriptor.runners, 'deploy'],
+					'Select a container to get logs'
+				);
 				const type =
 					container === 'deploy' ? LogType.Deploy : LogType.Job;
 


### PR DESCRIPTION
### Description
This pr adds the feature to delete your deploys.

### Additional Context
We could have added the whole list logic inside the delete.ts file, but in the future, I will be working on the --force flag, and that too will require the delete component, that's why made it reusable.

### How does it work?

```CPP

Step 1) Hit the below command:- 

$ metacall-deploy --delete

Step 2) It will provide the list of available deployments.

Step 3) Select one of the deployments and done.
```

### Checklist
- [x] My branch is up to date with the upstream master branch.