### PR TITLE
Added version updating hook

### DIFF
--- a/githooks/common.js
+++ b/githooks/common.js
@@ -1,0 +1,37 @@
+const { spawn } = require('child_process');
+
+const debug = !!process.env.DEBUG_HOOKS;
+const debugLog = debug ? ((...params) => console.log(...params)) : (() => {});
+
+const run = (cmd, args = [], config = {}) => new Promise((ok, nope) => {
+	const child = spawn(cmd, args, config);
+	
+	let stderr = '';
+	let stdout = '';
+
+	child.stderr.on('data', data => {
+		stderr += data
+		debugLog('> stderr:', data.toString().trim());
+	});
+	child.stdout.on('data', data => {
+		stdout += data
+		debugLog('> stdout:', data.toString().trim());
+	});
+	child.on('close', (code, signal) => {
+		if (code !== 0) {
+			console.error('Exited with code', code);
+			return nope({
+				message: stderr,
+				exit: code,
+				data: { code, signal, stderr, stdout, child }
+			});
+		}
+		ok({ code, signal, stderr, stdout, child });
+	});
+});
+
+module.exports = {
+	debug,
+	debugLog,
+	run
+};

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const { debugLog } = require('./common');
+
+const PREFIX = 'pre-push';
+
+const hooks = [
+	'update-version'
+];
+
+if (require.main === module) {
+	for (const hook of hooks) {
+		const filename = PREFIX + '-' + hook;
+		debugLog('Executing hook:', filename);
+		const { main } = require('./' + filename);
+		main(process.argv.slice(2));
+	}
+}

--- a/githooks/pre-push-update-version
+++ b/githooks/pre-push-update-version
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+
+const { debugLog, run } = require('./common');
+
+const main = async (args) => {
+	let resp;
+	try {
+		/*
+		// Not needed: https://stackoverflow.com/a/37927943/12547142
+		
+		const cwd = process.cwd();
+		debugLog('Current working directory:', cwd);
+
+		resp = await run('git', ['rev-parse', '--show-toplevel']);
+		const root = resp.stdout.trim();
+		debugLog('Repository root directory:', root);
+		
+		// Ensuring the current working directory is at the repository root
+		// ...
+		*/
+
+		const root = process.cwd();
+
+		debugLog('Inside update-version hook.');
+		debugLog('Command-line arguments:', args);
+
+		const remoteName = args[0];
+		debugLog('Remote:', remoteName);
+
+		debugLog('Fetching tags...');
+		await run('git', ['fetch', '--tags', remoteName]);
+
+		debugLog('Retrieving the latest tag version...');
+		resp = await run('git', ['rev-list', '--tags', '--max-count=1']);
+		const latestTagCommit = resp.stdout.trim();
+		debugLog('Latest tag commit hash:', latestTagCommit);
+
+		resp = await run('git', ['describe', '--tags', latestTagCommit]);
+		const latestTag = resp.stdout.trim();
+		debugLog('Latest tag:', latestTag);
+		const latestVersion = latestTag.slice(1);
+		debugLog('=> Latest version:', latestVersion);
+
+		
+		debugLog('Retrieving the version from package.json...');
+		const package = require('../package.json');
+		const lockfile = require('../package-lock.json');
+		const { version: packageVersion } = package;
+		const { version: lockfileVersion } = lockfile;
+		debugLog('package.json version:', packageVersion);
+		debugLog('package-lock.json version:', lockfileVersion);
+		
+		let success = latestVersion === packageVersion && latestVersion === lockfileVersion;
+
+		if (success) {
+			debugLog('Versions match. No update needed.');
+		} else {
+			debugLog('Versions donn\'t match. Updating versions.');
+			if (packageVersion !== latestVersion) {
+				console.log('Updating package.json with version from latest tag...');
+				package.version = latestVersion;
+				fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(package, null, '\t'));
+				debugLog('Updated package.json.');
+			}
+			if (lockfileVersion !== latestVersion) {
+				console.log('Updating package-lock.json with version from latest tag...');
+				lockfile.version = latestVersion;
+				fs.writeFileSync(path.join(root, 'package-lock.json'), JSON.stringify(lockfile, null, '\t'));
+				debugLog('Updated package-lock.json.');
+			}
+			debugLog('Updated versions.');
+			await run('git', ['add', 'package.json']);
+			await run('git', ['add', 'package-lock.json']);
+			await run('git', ['commit', '-m', 'Updating version to ' + latestTag]);
+
+			resp = await run('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+			const currentBranch = resp.stdout.trim();
+			debugLog('Current branch:', currentBranch);
+
+			process.stderr.write('\033[0;31mYour push has been rejected in order to update the versions in package.json and package-lock.json according to the latest tag.\033[0m\n');
+			process.stderr.write('\033[0;32mPush again with: \033[0mgit push ' + remoteName + ' ' + currentBranch + ' ' + latestTag + '\n');
+		}
+		return process.exit(success ? 0 : 1);
+	} catch (e) {
+		e && e.data && e.data.signal && debugLog('Signal:', e.data.signal);
+		e && e.data && e.data.stdout && debugLog('stdout:', '\n----------------------', e.data.stdout, '\n----------------------');
+		console.error(e.message);
+		process.exit(e.exit);
+	}
+};
+
+module.exports = { main };
+
+if (require.main === module) {
+	main(process.argv.slice(2));
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"coverage": "nyc npm run test",
 		"unit": "npm run --silent test -- --ignore **/*.integration.spec.js",
 		"prepublishOnly": "npm run --silent build",
+		"postinstall": "git config --local core.hooksPath githooks",
 		"build": "npm run --silent lint && tsc",
 		"lint": "eslint . --ignore-pattern dist",
 		"fix": "eslint . --ignore-pattern dist --fix",


### PR DESCRIPTION
# Added version updating hook
- This PR adds a version-updating pre-push Git hook to the project.
- The functionality is similar to what we already have implemented for [`metacall/core`](https://github.com/metacall/core).
- The script is written in pure JavaScript to make it cross-platform.
- An `npm ci` or `npm install` is required on all cloned repositories once the PR is merged.

CC: @viferga 

Signed-off-by: Param Siddharth <contact@paramsid.com>