### PR TITLE
Adds .env and dotenv for tests to run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+METACALL_AUTH_EMAIL=user@email.com
+METACALL_AUTH_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .nyc_output
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@metacall/deploy",
-	"version": "0.1.13",
+	"version": "0.1.14",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@metacall/deploy",
-			"version": "0.1.13",
+			"version": "0.1.14",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -14,6 +14,7 @@
 				"archiver": "^5.0.2",
 				"chalk": "^4.1.1",
 				"console-table-printer": "^2.10.0",
+				"dotenv": "^16.0.3",
 				"gauge": "^3.0.0",
 				"ini": "^1.3.5",
 				"inquirer": "^8.1.0",
@@ -1942,6 +1943,14 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/ecdsa-sig-formatter": {
@@ -6625,6 +6634,11 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"dotenv": {
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
 		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@metacall/deploy",
-	"version": "0.1.13",
+	"version": "0.1.14",
 	"description": "Tool for deploying into MetaCall FaaS platform.",
 	"main": "dist/index.js",
 	"bin": {
@@ -111,6 +111,7 @@
 		"@typescript-eslint/parser": "^5.11.0",
 		"concat-stream": "^2.0.0",
 		"cross-spawn": "^7.0.3",
+		"dotenv": "^16.0.3",
 		"eslint": "^7.13.0",
 		"eslint-config-prettier": "^6.15.0",
 		"eslint-plugin-prettier": "^3.1.4",

--- a/src/test/cmd.ts
+++ b/src/test/cmd.ts
@@ -1,10 +1,12 @@
 import API from '@metacall/protocol/protocol';
 import concat from 'concat-stream';
 import spawn from 'cross-spawn';
+import * as dotenv from 'dotenv';
 import { existsSync } from 'fs';
 import { constants } from 'os';
 import args from '../cli/args';
 import { startup } from '../startup';
+dotenv.config();
 
 const PATH = process.env.PATH;
 const HOME = process.env.HOME;


### PR DESCRIPTION
Adding env variables for the tests to pass.

- The `dotenv` npm package added to devDeps
- Using the dotenv config() to load .env variables
- Adds a example .env file to fill up locally

❤️ 