### PR TITLE
Neglected plans for --dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { Plans } from '@metacall/protocol/plan';
 import API, { API as APIInterface } from '@metacall/protocol/protocol';
 import { promises as fs } from 'fs';
 import { dirname, join } from 'path';
@@ -59,11 +60,18 @@ void (async () => {
 
 	if (args['force']) await force(api);
 
+	// On line 63, we passed Essential to the FAAS in dev environment,
+	// the thing is there is no need of plans in Local Faas (--dev),
+	// this could have been handlled neatly if we created deploy as a State Machine,
+	// think about a better way
+
+	const planSelected: Plans = args['dev'] ? Plans.Essential : await plan(api);
+
 	if (args['addrepo']) {
 		try {
 			return await deployFromRepository(
 				api,
-				await plan(api),
+				planSelected,
 				new URL(args['addrepo']).href
 			);
 		} catch (e) {
@@ -86,7 +94,7 @@ void (async () => {
 		}
 
 		try {
-			await deployPackage(rootPath, api, await plan(api));
+			await deployPackage(rootPath, api, planSelected);
 		} catch (e) {
 			error(String(e));
 		}

--- a/src/listPlans.ts
+++ b/src/listPlans.ts
@@ -1,11 +1,18 @@
-import { API as APIInterface } from '@metacall/protocol/protocol';
-import { info } from './cli/messages';
+import {
+	API as APIInterface,
+	ProtocolError
+} from '@metacall/protocol/protocol';
+import { apiError, info } from './cli/messages';
 import { planFetch } from './plan';
 
 export const listPlans = async (api: APIInterface): Promise<void> => {
-	const availPlans = await planFetch(api);
+	try {
+		const availPlans = await planFetch(api);
 
-	Object.keys(availPlans).forEach(el => {
-		info(`${el} : ${availPlans[el]}`);
-	});
+		Object.keys(availPlans).forEach(el => {
+			info(`${el} : ${availPlans[el]}`);
+		});
+	} catch (err) {
+		apiError(err as ProtocolError);
+	}
 };


### PR DESCRIPTION
For Local Faas ( --dev ) we are using Plans.Essential as default, it's a workaround, I have done it for now because there is no need for plans on --dev and if I did'nt did this then it would have prompted user for the plans, there is a better way, we can use if else but for now it's fine.