### PR TITLE
fix: token expiration bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@metacall/deploy",
-	"version": "0.1.28",
+	"version": "0.1.26",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@metacall/deploy",
-			"version": "0.1.28",
+			"version": "0.1.26",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@metacall/deploy",
-	"version": "0.1.28",
+	"version": "0.1.26",
 	"description": "Tool for deploying into MetaCall FaaS platform.",
 	"main": "dist/index.js",
 	"bin": {

--- a/src/cli/validateToken.ts
+++ b/src/cli/validateToken.ts
@@ -1,10 +1,13 @@
 import { API as APIInterface } from '@metacall/protocol/protocol';
-import { save } from '../config';
+import { unlink } from 'fs/promises';
+import { configFilePath, save } from '../config';
+import { exists } from '../utils';
 import args from './args';
 import { error, info } from './messages';
 
 const handleValidateToken = async (api: APIInterface): Promise<void> => {
 	const validToken = await api.validate();
+
 	if (!validToken) {
 		const token = await api.refresh();
 		await save({ token });
@@ -22,6 +25,12 @@ const validateToken = async (api: APIInterface): Promise<void> => {
 
 			return error('FaaS is not serving locally.');
 		}
+
+		// Removing cache such that user will have to login again.
+
+		const configFile = configFilePath();
+
+		(await exists(configFile)) && (await unlink(configFile));
 
 		info('Try to login again!');
 


### PR DESCRIPTION
When token gets expired, the api.validate request fails, and we were not clearing the cache such that when user tries performing same steps again he will encounter login page, so this pr removes the cache.