### PR TITLE
GitHub Actions to Use Latest Versions of actions/checkout and actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup NodeJS
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: '16'
                   registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Changes Made :
- Updated the GitHub Actions workflow to use `actions/checkout@v4` for improved stability and features.
- Updated `actions/setup-node@v4` to ensure compatibility with Node.js version `16` and specified registry URL.

Reason for the Change :
This update ensures that our CI pipeline remains up-to-date with the latest improvements and fixes provided by GitHub Actions. By migrating to newer versions of `actions/checkout` and `actions/setup-node`, aim to enhance the reliability and performance of build and deployment processes. @viferga 