### PR TITLE
fix: grammar error in CLI unknown command message

### DIFF
--- a/src/cli/unknown.ts
+++ b/src/cli/unknown.ts
@@ -8,7 +8,7 @@ export const handleUnknownArgs = (): void => {
 	if (!(flags.length === 1 && (flags[0] === '--help' || flags[0] === '-h'))) {
 		const message = `${flags.join(
 			', '
-		)} does not exists as a valid command.`;
+		)} does not exist as a valid command.`;
 		warn(message);
 	}
 


### PR DESCRIPTION
Small fix. Changed 'does not exists' to 'does not exist' for better English flow.