### PR TITLE
fix: Apply `serverUrl` argument to `baseURL` before API initialization.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,10 @@ void (async () => {
 	if (args['logout']) return logout();
 
 	const config = await startup(args['confDir']);
+
+	if (args['serverUrl']) {
+		config.baseURL = args['serverUrl'];
+	}
 	const api: APIInterface = API(
 		config.token as string,
 		args['dev'] ? config.devURL : config.baseURL
@@ -172,9 +176,5 @@ void (async () => {
 		} catch (e) {
 			error(String(e));
 		}
-	}
-
-	if (args['serverUrl']) {
-		config.baseURL = args['serverUrl'];
 	}
 })();


### PR DESCRIPTION
### Description
This PR fixes a bug where the `--serverUrl` (`-u`) CLI flag had no effect because it was being applied to the configuration *after* the `api` client was already instantiated.

### Changes Made
Moved the configuration override block for `--serverUrl` to run immediately after startup but before `API()` is initialized. This enables developers to target their own local/remote FaaS instances without being restricted to only `localhost:9000` via the `--dev` flag.

Fixes issue #195

### Notes
- As a side note: The explicit `--dev` flag might become redundant and could potentially be removed in the future now that `--serverUrl` works correctly.