### PR TITLE
Fix TypeScript build by adding DOM lib to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"lib": ["ES2020"],
+		"lib": ["ES2020", "DOM"],
 		"target": "ES2019",
 		"module": "CommonJS",
 		"outDir": "dist",


### PR DESCRIPTION
## Summary

This PR fixes TypeScript build errors caused by missing DOM types
from @types/mapbox-gl.

## Problem

Running `npm run build` resulted in multiple TypeScript errors such as:

- Cannot find name 'HTMLElement'
- Cannot find name 'MouseEvent'
- Cannot find name 'HTMLImageElement'

The errors were caused by missing DOM library definitions in tsconfig.json.

## Solution

Added `"DOM"` to the `lib` array inside `compilerOptions` in tsconfig.json.

After this change:
- `npm run build` completes successfully
- TypeScript compiles without errors

## Testing

Build verified locally using:
npm run build