### PR TITLE
Fix force flag when no deployment exists (#153)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5529,9 +5529,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"license": "MIT",
 			"optional": true
 		},

--- a/src/force.ts
+++ b/src/force.ts
@@ -8,8 +8,13 @@ export const force = async (api: APIInterface): Promise<string> => {
 	info('Trying to deploy forcefully!');
 
 	const suffix = args['addrepo']
-		? args['addrepo']?.split('com/')[1].split('/').join('-')
-		: args['projectName'].toLowerCase();
+		? args['addrepo']?.split('com/')[1]?.split('/').join('-')
+		: args['projectName']?.toLowerCase();
+
+	if (!suffix) {
+		info('No valid project identifier found. Proceeding normally.');
+		return '';
+	}
 
 	let res = '';
 
@@ -19,17 +24,26 @@ export const force = async (api: APIInterface): Promise<string> => {
 		).filter(dep => dep.deploy === suffix);
 
 		const repo: Deployment[] = (await api.inspect()).filter(
-			dep => dep.suffix == suffix
+			dep => dep.suffix === suffix
 		);
 
-		if (repo) {
+		if (repo.length > 0) {
 			res = await del(
 				repo[0].prefix,
 				repo[0].suffix,
 				repo[0].version,
 				api
 			);
-			args['plan'] = repoSubscriptionDetails[0].plan;
+
+			if (repoSubscriptionDetails.length > 0) {
+				args['plan'] = repoSubscriptionDetails[0].plan;
+			}
+
+			info('Existing deployment removed successfully.');
+		} else {
+			info(
+				'No existing deployment found. Proceeding with normal deployment.'
+			);
 		}
 	} catch (e) {
 		error(
@@ -39,5 +53,3 @@ export const force = async (api: APIInterface): Promise<string> => {
 
 	return res;
 };
-
-// One improvement can be done is, if with force flag, a person tries to deploy an app, and the app is not present actually there then it should behave as normal deployment procedure


### PR DESCRIPTION
Fixes #153.

Previously, using --force would fail when no existing deployment
was found because repo[0] was accessed without checking length.

Now:
- Checks repo.length > 0 before deletion
- Proceeds with normal deployment if no existing deployment is found
- Adds defensive checks for subscription details

Build and lint pass successfully.