### PR TITLE
feat: add Ctrl+C cancel hint to persistent screens and Exit option to list prompts

### DIFF
--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -270,6 +270,7 @@ const inspectPrint: InspectPrint = {
 			});
 
 			p.printTable();
+			process.stdout.write('\n\x1b[2m  Press Ctrl+C to cancel.\x1b[0m\n');
 			await sleep(5000);
 		}
 	},

--- a/src/cli/selection.ts
+++ b/src/cli/selection.ts
@@ -6,15 +6,27 @@ import {
 import { Plans } from '@metacall/protocol/plan';
 import { prompt } from 'inquirer';
 
+const EXIT_OPTION = 'Exit';
+
+const handleExit = (value: string): void => {
+	if (value === EXIT_OPTION) {
+		process.stdout.write('\nExiting...\n');
+		process.exit(0);
+	}
+};
+
 export const loginSelection = (methods: string[]): Promise<string> =>
 	prompt<{ method: string }>([
 		{
 			type: 'list',
 			name: 'method',
 			message: 'Select the login method',
-			choices: methods
+			choices: [...methods, EXIT_OPTION]
 		}
-	]).then((res: { method: string }) => res.method);
+	]).then((res: { method: string }) => {
+		handleExit(res.method);
+		return res.method;
+	});
 
 export const fileSelection = (
 	message: string,
@@ -52,22 +64,34 @@ export const planSelection = (
 			type: 'list',
 			name: 'plan',
 			message,
-			choices: availablePlans
+			choices: [...availablePlans, EXIT_OPTION]
 		}
-	]).then((res: { plan: Plans }) => res.plan);
+	]).then((res: { plan: Plans }) => {
+		handleExit(res.plan as string);
+		return res.plan;
+	});
 
 export const listSelection = (
 	list: string[] | { name: string; value: string }[],
 	message: string
-): Promise<string> =>
-	prompt<{ container: string }>([
+): Promise<string> => {
+	const choicesWithExit = [
+		...list,
+		{ name: EXIT_OPTION, value: EXIT_OPTION }
+	];
+
+	return prompt<{ container: string }>([
 		{
 			type: 'list',
 			name: 'container',
 			message,
-			choices: list
+			choices: choicesWithExit
 		}
-	]).then((res: { container: string }) => res.container);
+	]).then((res: { container: string }) => {
+		handleExit(res.container);
+		return res.container;
+	});
+};
 
 export const consentSelection = (message: string): Promise<boolean> =>
 	prompt<{ consent: boolean }>([

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -24,6 +24,7 @@ const showLogs = async (
 	);
 
 	info(`Getting ${type} logs for ${suffix}...`);
+	process.stdout.write('\x1b[2m  Press Ctrl+C to cancel.\x1b[0m\n');
 
 	let logsTill: string[] = [''];
 


### PR DESCRIPTION
Implements #154 based on maintainer feedback from the closed PR #173.

## Changes

- `src/cli/inspect.ts`: Shows `Press Ctrl+C to cancel` at the bottom of 
  the persistent table loop (the `for(;;)` loop that refreshes every 5s)
- `src/logs.ts`: Shows `Press Ctrl+C to cancel` in the persistent logs 
  loop (the `while` loop that polls until status = ready)
- `src/cli/selection.ts`: Adds an "Exit" option to list-type prompts 
  (login, plan, container selection) for graceful exit without Ctrl+C

## Approach

Based on @viferga's review on #173:
- Ctrl+C hint shown **only** on persistent/long-running screens, not simple input prompts
- List prompts get an **"Exit" option** instead, for clean graceful exit
- Message displayed at bottom of output, after table/log content

Fixes #154