### PR TITLE
Enable local FaaS tests and install Python bindings (#181, #172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,21 +41,21 @@ jobs:
                   echo 'METACALL_AUTH_PASSWORD="${{ secrets.METACALL_AUTH_PASSWORD }}"' >> .env
                   npm run coverage
 
-            # # TODO: This depends on: https://github.com/metacall/faas/issues/78
-            # - name: Run Tests (local)
-            #   run: |
-            #       cd ..
-            #       git clone https://github.com/metacall/faas.git
-            #       cd faas
-            #       npm install
-            #       npm run build
-            #       node dist/index.js --version
-            #       cd ../deploy
-            #       export TEST_DEPLOY_LOCAL="true"
-            #       node ../faas/dist/index.js &
-            #       sleep 10
-            #       mv .env.example .env
-            #       npm run coverage
+            # Run local tests integrating to faas for pull requests to ensure that the CLI works correctly without relying on the production environment
+            - name: Run Tests (local)
+              run: |
+                  cd ..
+                  git clone https://github.com/metacall/faas.git
+                  cd faas
+                  npm install
+                  npm run build
+                  node dist/index.js --version
+                  cd ../deploy
+                  export TEST_DEPLOY_LOCAL="true"
+                  node ../faas/dist/index.js &
+                  sleep 10
+                  mv .env.example .env
+                  npm run coverage
 
             - name: Publish
               uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
Fixes #181 and Fixes #172.

**What changed:**
* Added `pip3 install metacall` to the CLI setup step. This resolves the `ModuleNotFoundError` during the Python integration tests.
* Uncommented the local FaaS testing block in `ci.yml`. Since the blocking issue (`faas#78` execution path) was resolved upstream by @viferga , this local integration test now passes successfully. 

This ensures PRs are properly tested locally since the production tests are skipped for `pull_request` events.