### PR TITLE
fix: validate inspect format before authentication to prevent login prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -908,7 +908,6 @@
 			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.62.0",
 				"@typescript-eslint/types": "5.62.0",
@@ -1077,7 +1076,6 @@
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1466,7 +1464,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -2269,7 +2266,6 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "7.12.11",
 				"@eslint/eslintrc": "^0.4.3",
@@ -4263,7 +4259,6 @@
 			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"@istanbuljs/load-nyc-config": "^1.0.0",
 				"@istanbuljs/schema": "^0.1.2",
@@ -4737,7 +4732,6 @@
 			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -5510,7 +5504,6 @@
 			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -5527,13 +5520,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,17 @@ void (async () => {
 	}
 
 	if (args['logout']) return logout();
-
+	if (
+		args['inspect'] !== undefined &&
+		args['inspect'] !== null &&
+		args['inspect'] === InspectFormat.Invalid
+	) {
+		const values = Object.keys(InspectFormat)
+			.filter(k => k !== 'Invalid')
+			.join(', ');
+		error(`Invalid format passed to inspect, valid formats are: ${values}`);
+		return;
+	}
 	const config = await startup(args['confDir']);
 	const api: APIInterface = API(
 		config.token as string,
@@ -68,9 +78,7 @@ void (async () => {
 	);
 
 	await validateToken(api);
-
 	if (args['listPlans']) return await listPlans(api);
-
 	if (args['inspect'] === null) {
 		args['inspect'] = InspectFormat.Table;
 	}


### PR DESCRIPTION
> Fixes the issue where passing an invalid format to (--inspect) (e.g. --inspect yeet) would show a login prompt instead of an error message.

> Problem:
The inspect format validation was happening after startup() and validateToken(), which triggered the login prompt before the invalid format could be caught.

> Fix:
Moved the invalid format check to before startup() so it exits early with a proper error message without requiring authentication.

> Expected output:
X Invalid format passed to inspect, valid formats are: Table, Raw, OpenAPIv3

> Testing:
Both inspect tests now pass:
✔ Should fail --inspect command with proper output (251ms)
✔ Should fail --inspect command with proper output (3019ms)
Total: 8 passing (it was 7 before this fix)

> AI Disclosure:
Used Claude (AI) for debugging assistance. All changes reviewed, tested, and understood by me.