### PR TITLE
Fix: `--force` exits with error when no prior deployment exists

### DIFF
--- a/src/force.ts
+++ b/src/force.ts
@@ -22,22 +22,31 @@ export const force = async (api: APIInterface): Promise<string> => {
 			dep => dep.suffix == suffix
 		);
 
-		if (repo) {
+		if (repo.length > 0) {
+			// An existing deployment was found — delete it before re-deploying.
 			res = await del(
 				repo[0].prefix,
 				repo[0].suffix,
 				repo[0].version,
 				api
 			);
-			args['plan'] = repoSubscriptionDetails[0].plan;
+
+			// Restore the plan from the subscription that owned this deployment
+			// so the re-deploy is charged to the same subscription slot.
+			if (repoSubscriptionDetails.length > 0) {
+				args['plan'] = repoSubscriptionDetails[0].plan;
+			}
+		} else {
+			// No prior deployment found skip deletion and proceed normally.
+			info(
+				'No existing deployment found for this project. Continuing as a fresh deploy.'
+			);
 		}
 	} catch (e) {
 		error(
-			'Deployment Aborted because this directory is not being used by any applications.'
+			'Deployment Aborted due to an unexpected error while checking existing deployments.'
 		);
 	}
 
 	return res;
 };
-
-// One improvement can be done is, if with force flag, a person tries to deploy an app, and the app is not present actually there then it should behave as normal deployment procedure

--- a/src/test/force.spec.ts
+++ b/src/test/force.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for src/force.ts
+ *
+ * Fixes: https://github.com/metacall/deploy/issues #208
+ * "force() exits with error when no existing deployment matches the target suffix"
+ *
+ * All tests use a mock API, no network or real credentials required.
+ */
+
+import { Deployment, DeployStatus } from '@metacall/protocol/deployment';
+import { Plans } from '@metacall/protocol/plan';
+import {
+	API as APIInterface,
+	SubscriptionDeploy
+} from '@metacall/protocol/protocol';
+import { strictEqual } from 'assert';
+import { basename } from 'path';
+import args from '../cli/args';
+import { force } from '../force';
+
+// force() derives the suffix from args['projectName'].toLowerCase() when
+// --addrepo is not set. Mirror that here so mock data aligns with the filter.
+const TEST_SUFFIX = basename(process.cwd()).toLowerCase();
+
+const makeDeployment = (): Deployment => ({
+	status: 'ready' as DeployStatus,
+	prefix: 'test-prefix',
+	suffix: TEST_SUFFIX,
+	version: 'v1',
+	packages: {} as Deployment['packages'],
+	ports: []
+});
+
+const makeSubscriptionDeploy = (): SubscriptionDeploy => ({
+	id: 'sub-id-abc123',
+	plan: Plans.Essential,
+	date: Date.now(),
+	deploy: TEST_SUFFIX
+});
+
+// Only the three methods force() actually invokes are given real stubs.
+// Everything else resolves to a safe empty value.
+const makeMockApi = (
+	deployments: Deployment[],
+	subscriptionDeploys: SubscriptionDeploy[]
+): APIInterface => ({
+	refresh: () => Promise.resolve(''),
+	validate: () => Promise.resolve(true),
+	deployEnabled: () => Promise.resolve(true),
+	listSubscriptions: () => Promise.resolve({}),
+	listSubscriptionsDeploys: () => Promise.resolve(subscriptionDeploys),
+	inspect: () => Promise.resolve(deployments),
+	upload: () => Promise.resolve(''),
+	add: () => Promise.resolve({ id: '' }),
+	deploy: () => Promise.resolve({ suffix: '', prefix: '', version: '' }),
+	deployDelete: () => Promise.resolve('deleted-ok'),
+	logs: () => Promise.resolve(''),
+	branchList: () => Promise.resolve({ branches: ['main'] }),
+	fileList: () => Promise.resolve([])
+});
+
+describe('Unit force() emptyrepo guard', () => {
+	const originalPlan = args['plan'];
+
+	afterEach(() => {
+		args['plan'] = originalPlan;
+	});
+
+	it('returns empty string and does not throw when no deployment exists', async () => {
+		const api = makeMockApi([], []);
+		const result = await force(api);
+		strictEqual(result, '');
+	});
+
+	it('deletes the existing deployment and restores args.plan from subscription', async () => {
+		const api = makeMockApi([makeDeployment()], [makeSubscriptionDeploy()]);
+		const result = await force(api);
+
+		strictEqual(result, 'deleted-ok');
+		strictEqual(args['plan'], Plans.Essential);
+	});
+
+	it('deletes deployment without crashing when subscription list has no match', async () => {
+		const api = makeMockApi([makeDeployment()], []);
+		const result = await force(api);
+
+		// Deletion succeeds; args.plan stays unchanged since no subscription matched.
+		strictEqual(result, 'deleted-ok');
+		strictEqual(args['plan'], originalPlan);
+	});
+});


### PR DESCRIPTION

Closes #208

### Problem

Running `metacall-deploy --force` on a project that has never been deployed exits with:
X Deployment Aborted because this directory is not being used by any applications.

and the deploy never starts.

The root cause: `api.inspect()` returns an empty array when no deployment exists. The old check `if (repo)` is always truthy for an empty array in JS, so the code proceeds to `repo[0].prefix` — which is `undefined` — and throws. The catch block then calls `error()` and exits with code `1`.

The [existing comment in `force.ts`](https://github.com/metacall/deploy/blob/master/src/force.ts) already documents the intended behavior: if no deployment is found, `--force` should skip deletion and continue as a normal deploy.

### Changes

**`src/force.ts`**
- Replace `if (repo)` with `if (repo.length > 0)` to correctly detect an empty result
- Guard `repoSubscriptionDetails[0]` access independently  `listSubscriptionsDeploys()` and `inspect()` are separate API calls and their results may not align
- Show an info message when skipping deletion so the user understands what's happening
- Update the catch message to accurately describe what it covers

**`src/test/force.spec.ts`** *new file*
- Three unit tests using a mock API — no credentials or network required:
  1. Empty `inspect()` → returns `''` without throwing (regression test)
  2. Deployment + subscription found → deletes and restores `args.plan`
  3. Deployment found, no subscription match → deletes without crashing on `repoSubscriptionDetails[0]`

### Testing

```sh
# unit tests only — no credentials needed
./node_modules/.bin/mocha dist/test/force.spec.js

# full local CI steps
npm run lint
npm run build
```

All pass. Integration tests require API credentials and are only run on push to `master` per the existing CI workflow.
<img width="996" height="452" alt="image" src="https://github.com/user-attachments/assets/4f54458e-c510-4d1d-a27f-400d57bcc435" />

