### PR TITLE
fix: support non-GitHub repositories in `--force` url parsing

### DIFF
--- a/src/force.ts
+++ b/src/force.ts
@@ -4,12 +4,24 @@ import args from './cli/args';
 import { error, info } from './cli/messages';
 import { del } from './delete';
 
+export const getSuffixFromUrl = (urlStr: string): string => {
+	const url = new URL(urlStr);
+	return url.pathname.replace(/^\//, '').split('/').join('-');
+};
+
 export const force = async (api: APIInterface): Promise<string> => {
 	info('Trying to deploy forcefully!');
 
-	const suffix = args['addrepo']
-		? args['addrepo']?.split('com/')[1].split('/').join('-')
-		: args['projectName'].toLowerCase();
+	let suffix: string;
+	if (args['addrepo']) {
+		try {
+			suffix = getSuffixFromUrl(args['addrepo']);
+		} catch (e) {
+			return error('Invalid repository URL');
+		}
+	} else {
+		suffix = args['projectName'].toLowerCase();
+	}
 
 	let res = '';
 

--- a/src/test/force.spec.ts
+++ b/src/test/force.spec.ts
@@ -1,0 +1,29 @@
+import { strictEqual, throws } from 'assert';
+import { getSuffixFromUrl } from '../force';
+
+describe('force URL parsing logic', () => {
+	it('should parse GitHub URLs correctly', () => {
+		strictEqual(
+			getSuffixFromUrl('https://github.com/mygroup/myrepo'),
+			'mygroup-myrepo'
+		);
+	});
+
+	it('should parse GitLab URLs correctly', () => {
+		strictEqual(
+			getSuffixFromUrl('https://gitlab.com/mygroup/myrepo'),
+			'mygroup-myrepo'
+		);
+	});
+
+	it('should parse arbitrary URLs correctly', () => {
+		strictEqual(
+			getSuffixFromUrl('http://git.mycompany.local/group/subgroup/repo'),
+			'group-subgroup-repo'
+		);
+	});
+
+	it('should throw on invalid URLs', () => {
+		throws(() => getSuffixFromUrl('not-a-valid-url'));
+	});
+});


### PR DESCRIPTION
### Problem
This PR fixes a bug where the `--force` option crashes when passing non-GitHub repository URLs via `--addrepo`. It replaces the brittle, hardcoded `split('com/')` approach with native `new URL()` parsing to make suffix generation host-agnostic and robust against any valid repository URL (GitLab, self-hosted `.local` or `.org`, etc.).

### Changes
1. Refactored `src/force.ts` to use `new URL()` for parsing paths.
2. Extracted URL extraction logic into the testable pure function `getSuffixFromUrl`.
3. Created unit tests in `src/test/force.spec.ts` using Mocha to ensure any given URL is handled properly, and invalid URLs don't crash the deploy process.

### Resolves
Resolves #210

### Testing
<img width="938" height="432" alt="image" src="https://github.com/user-attachments/assets/e2a10120-304f-4842-8355-9055a1261a02" />