### PR TITLE
fix: ensure non-zero exit code for unknown CLI flags

### DIFF
--- a/src/cli/unknown.ts
+++ b/src/cli/unknown.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '../deploy';
 import { printHelp } from '../help';
 import args from './args';
 import { warn } from './messages';
@@ -5,11 +6,16 @@ import { warn } from './messages';
 export const handleUnknownArgs = (): void => {
 	const flags = args['_unknown'];
 
-	if (!(flags.length === 1 && (flags[0] === '--help' || flags[0] === '-h'))) {
+	const isHelpFlag =
+		flags.length === 1 && (flags[0] === '--help' || flags[0] === '-h');
+
+	if (!isHelpFlag) {
 		const message = `${flags.join(
 			', '
 		)} does not exist as a valid command.`;
 		warn(message);
+		printHelp(ErrorCode.InvalidArguments);
+		return;
 	}
 
 	printHelp();

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -30,7 +30,8 @@ export enum ErrorCode {
 	NotFoundRootPath = 3,
 	AccountDisabled = 4,
 	DeployPackageFailed = 5,
-	DeployRepositoryFailed = 6
+	DeployRepositoryFailed = 6,
+	InvalidArguments = 7
 }
 
 export const deployPackage = async (

--- a/src/help.ts
+++ b/src/help.ts
@@ -61,7 +61,7 @@ Examples:
 For more information, visit: https://github.com/metacall/deploy
 `;
 
-export const printHelp = (): void => {
+export const printHelp = (exitCode: ErrorCode = ErrorCode.Ok): void => {
 	console.log(helpText);
-	return process.exit(ErrorCode.Ok);
+	return process.exit(exitCode);
 };

--- a/src/test/unknown.spec.ts
+++ b/src/test/unknown.spec.ts
@@ -1,0 +1,127 @@
+import { strictEqual } from 'assert';
+import { ErrorCode } from '../deploy';
+import { printHelp } from '../help';
+import args from '../cli/args';
+import { handleUnknownArgs } from '../cli/unknown';
+
+/**
+ * Stubs process.exit so it doesn't terminate the test runner.
+ * Returns the captured exit code via a thrown sentinel error.
+ */
+const captureExitCode = (fn: () => void): number => {
+	/* eslint-disable @typescript-eslint/unbound-method */
+	const original = process.exit;
+	const originalLog = console.log;
+	/* eslint-enable @typescript-eslint/unbound-method */
+
+	let captured: number | undefined;
+
+	// Suppress help text output during tests
+	console.log = () => undefined;
+
+	process.exit = ((code?: number) => {
+		captured = code ?? 0;
+		throw new Error(`__process_exit__:${captured}`);
+	}) as typeof process.exit;
+
+	try {
+		fn();
+	} catch (e) {
+		if (
+			!(e instanceof Error) ||
+			!e.message.startsWith('__process_exit__')
+		) {
+			process.exit = original;
+			console.log = originalLog;
+			throw e;
+		}
+	} finally {
+		process.exit = original;
+		console.log = originalLog;
+	}
+
+	if (captured === undefined) {
+		throw new Error('process.exit was never called');
+	}
+
+	return captured;
+};
+
+// printHelp
+describe('printHelp exit codes', () => {
+	it('exits with 0 (ErrorCode.Ok) when called with no argument', () => {
+		const code = captureExitCode(() => printHelp());
+		strictEqual(code, ErrorCode.Ok);
+	});
+
+	it('exits with ErrorCode.Ok (0) when called with ErrorCode.Ok explicitly', () => {
+		const code = captureExitCode(() => printHelp(ErrorCode.Ok));
+		strictEqual(code, ErrorCode.Ok);
+	});
+
+	it('exits with ErrorCode.InvalidArguments (7) when called with ErrorCode.InvalidArguments', () => {
+		const code = captureExitCode(() =>
+			printHelp(ErrorCode.InvalidArguments)
+		);
+		strictEqual(code, ErrorCode.InvalidArguments);
+	});
+
+	it('exits with the exact numeric code passed in', () => {
+		// Verify the parameter is forwarded faithfully for any code value
+		const code = captureExitCode(() =>
+			printHelp(ErrorCode.DeployPackageFailed)
+		);
+		strictEqual(code, ErrorCode.DeployPackageFailed);
+	});
+});
+
+// handleUnknownArgs
+describe('handleUnknownArgs exit codes', () => {
+	// Keep originals so we can restore after each test
+	let originalUnknown: string[];
+
+	before(() => {
+		originalUnknown = (args as unknown as Record<string, unknown>)[
+			'_unknown'
+		] as string[];
+	});
+
+	after(() => {
+		(args as unknown as Record<string, unknown>)['_unknown'] =
+			originalUnknown;
+	});
+
+	const setUnknown = (flags: string[]) => {
+		(args as unknown as Record<string, unknown>)['_unknown'] = flags;
+	};
+
+	it('exits with ErrorCode.InvalidArguments when an unknown flag is passed', () => {
+		setUnknown(['--not-a-real-flag']);
+		const code = captureExitCode(() => handleUnknownArgs());
+		strictEqual(code, ErrorCode.InvalidArguments);
+	});
+
+	it('exits with ErrorCode.InvalidArguments for multiple unknown flags', () => {
+		setUnknown(['--foo', '--bar']);
+		const code = captureExitCode(() => handleUnknownArgs());
+		strictEqual(code, ErrorCode.InvalidArguments);
+	});
+
+	it('exits with ErrorCode.Ok (0) when --help is the only flag', () => {
+		setUnknown(['--help']);
+		const code = captureExitCode(() => handleUnknownArgs());
+		strictEqual(code, ErrorCode.Ok);
+	});
+
+	it('exits with ErrorCode.Ok (0) when -h is the only flag', () => {
+		setUnknown(['-h']);
+		const code = captureExitCode(() => handleUnknownArgs());
+		strictEqual(code, ErrorCode.Ok);
+	});
+
+	it('exits with ErrorCode.InvalidArguments when --help is combined with other flags', () => {
+		setUnknown(['--help', '--extra']);
+		const code = captureExitCode(() => handleUnknownArgs());
+		strictEqual(code, ErrorCode.InvalidArguments);
+	});
+});


### PR DESCRIPTION

### Problem
Previously, when an unrecognized flag was passed to the CLI (e.g., `metacall-deploy --invalid`), the program would print a warning and the help message but exit with code `0`. This made it impossible for CI/CD pipelines or scripts to detect usage errors.

### What changed?
1. **`src/deploy.ts`**: Introduced `ErrorCode.InvalidArguments = 7` to the `ErrorCode` enum.
2. **`src/help.ts`**: Refactored `printHelp()` to accept an optional `exitCode` parameter (defaulting to `ErrorCode.Ok` for backward compatibility and explicit `--help` calls).
3. **`src/cli/unknown.ts`**: Updated `handleUnknownArgs()` to call `printHelp(ErrorCode.InvalidArguments)` when unknown flags are detected. It still exits with `0` for `-h` or `--help`.
4. **`src/test/unknown.spec.ts`**: Created a comprehensive unit test suite (9 tests) that stubs `process.exit` and `console.log` to verify that the correct exit codes are returned for various flag combinations (valid help, single unknown, multiple unknown, etc.).

### Resolves
Fixes #212 

### Testing
- `npm run unit` has been executed.
- Manual verification: Running `./dist/index.js --invalid-flag` now correctly returns an exit code of `7`.
<img width="813" height="374" alt="image" src="https://github.com/user-attachments/assets/b59fa39e-54c3-402b-9622-0295aed595af" />
