### PR TITLE
fix: crash when deployment not found in logs viewer

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -27,12 +27,19 @@ const showLogs = async (
 
 	let logsTill: string[] = [''];
 
-	let app: Deployment;
+	let app: Deployment | undefined;
 	let status: DeployStatus = 'create';
 
 	while (status !== 'ready') {
-		app = (await api.inspect()).filter(dep => dep.suffix === suffix)[0];
+		const deployments = (await api.inspect()).filter(
+			dep => dep.suffix === suffix
+		);
 
+		if (deployments.length === 0) {
+			error(`Deployment with suffix "${suffix}" not found`);
+		}
+
+		app = deployments[0];
 		status = app.status;
 		const prefix = app.prefix;
 


### PR DESCRIPTION
Fix: Crash when deployment not found in logs viewer

Problem:
Logs viewer crashes with "Cannot read property 'status' of undefined" when deployment doesn't exist.

Root cause:
app = (await api.inspect()).filter(dep => dep.suffix === suffix)[0];
// If filter returns [], app is undefined → crashes on app.status

Solution:
- Check if deployment exists before accessing properties
- Show clear error: "Deployment with suffix "{suffix}" not found"
- Split filter and array access for safety

Changes:
const deployments = (await api.inspect()).filter(dep => dep.suffix === suffix);
if (deployments.length === 0) {
    error(`Deployment with suffix "${suffix}" not found`);
}
app = deployments[0];