### PR TITLE
fix: buffer archiver stream into Blob for native fetch/FormData compatibility

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,11 +33,7 @@ const authToken = async (config: Config): Promise<string> => {
 				await api.validate();
 				break;
 			} catch (err) {
-				warn(
-					`Token invalid: ${String(
-						(err as ProtocolError).data
-					)}`
-				);
+				warn(`Token invalid: ${String((err as ProtocolError).data)}`);
 				token = await askToken();
 			}
 		}
@@ -45,11 +41,7 @@ const authToken = async (config: Config): Promise<string> => {
 		try {
 			await api.validate();
 		} catch (err) {
-			error(
-				`Token invalid: ${String(
-					(err as ProtocolError).data
-				)}`
-			);
+			error(`Token invalid: ${String((err as ProtocolError).data)}`);
 		}
 	}
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -35,7 +35,7 @@ const authToken = async (config: Config): Promise<string> => {
 			} catch (err) {
 				warn(
 					`Token invalid: ${String(
-						(err as ProtocolError).response?.data
+						(err as ProtocolError).data
 					)}`
 				);
 				token = await askToken();
@@ -47,7 +47,7 @@ const authToken = async (config: Config): Promise<string> => {
 		} catch (err) {
 			error(
 				`Token invalid: ${String(
-					(err as ProtocolError).response?.data
+					(err as ProtocolError).data
 				)}`
 			);
 		}
@@ -90,7 +90,7 @@ const authLogin = async (config: Config): Promise<string> => {
 				token = await login(email, password, config.baseURL);
 				break;
 			} catch (err) {
-				warn(String((err as ProtocolError).response?.data));
+				warn(String((err as ProtocolError).data));
 				args['email'] = args['password'] = undefined;
 				await askCredentials();
 			}
@@ -99,7 +99,7 @@ const authLogin = async (config: Config): Promise<string> => {
 		try {
 			token = await login(email, password, config.baseURL);
 		} catch (err) {
-			error(String((err as ProtocolError).response?.data));
+			error(String((err as ProtocolError).data));
 		}
 	}
 
@@ -158,7 +158,7 @@ const authSignup = async (config: Config): Promise<string> => {
 			);
 			break;
 		} catch (err) {
-			const errorMessage = String((err as ProtocolError).response?.data);
+			const errorMessage = String((err as ProtocolError).data);
 
 			if (errorMessage.includes('Account already exists')) {
 				info(

--- a/src/cli/messages.ts
+++ b/src/cli/messages.ts
@@ -75,8 +75,9 @@ export const error = (message: string, exitCode = 1): never => {
  * Log API error and exit (always shown)
  */
 export const apiError = (err: ProtocolError): never => {
-	const status = err.response?.status || 'unknown';
-	const data = err.response?.data as string;
+	const status: number | string = err.status ?? 'unknown';
+	const data: string =
+		typeof err.data === 'string' ? err.data : String(err.data ?? '');
 
 	if (isJson()) {
 		// eslint-disable-next-line no-console

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@
 */
 
 import { MetaCallJSON } from '@metacall/protocol/deployment';
-import archiver, { Archiver } from 'archiver';
+import archiver from 'archiver';
 import { parse } from 'dotenv';
 import { promises as fs } from 'fs';
 import { prompt } from 'inquirer';
@@ -109,7 +109,7 @@ export const zip = async (
 	pulse?: (name: string) => void,
 	hide?: () => void,
 	ignorePatterns?: string[]
-): Promise<Archiver> => {
+): Promise<Blob> => {
 	// Apply ignore patterns
 	files = filterFiles(files, ignorePatterns);
 	const archive = archiver('zip', {
@@ -137,13 +137,24 @@ export const zip = async (
 			: archive.file(file, { name: relative(source, file) });
 	}
 
-	if (hide) {
-		archive.on('finish', () => hide());
-	}
+	// Collect all compressed chunks into a Buffer, then wrap as a Blob.
+	// @metacall/protocol now uses native fetch + FormData which requires a
+	// Blob — Node.js Transform streams are not accepted by FormData.append().
+	const chunks: Buffer[] = [];
+	archive.on('data', (chunk: Buffer) => chunks.push(chunk));
 
-	await archive.finalize();
+	await new Promise<void>((resolve, reject) => {
+		archive.on('end', () => {
+			if (hide) hide();
+			resolve();
+		});
+		archive.on('error', reject);
+		void archive.finalize();
+	});
 
-	return archive;
+	return new Blob([Buffer.concat(chunks)], {
+		type: 'application/zip'
+	});
 };
 
 /**


### PR DESCRIPTION
## Problem

`@metacall/protocol` >= 0.1.27 switched from `axios` to native `fetch` + `FormData`. The `upload()` function now calls:

```ts
fd.append('raw', blob, 'blob');
```

This requires a **`Blob`** argument. Previously, `zip()` returned a Node.js `Transform` stream (`Archiver`), which native `FormData.append()` cannot handle -- it corrupts or truncates the multipart body.

The FaaS server's `busboy` then throws `Unexpected end of form` and returns **HTTP 400**, causing the CI integration tests to fail.

## Fix

Changed `zip()` in `src/utils.ts` to collect all archiver output chunks into a `Buffer` and return it wrapped in a `Blob`:

- Listen for `data` events on the archiver to collect chunks
- - Call `archive.finalize()` and wait for the `end` event
- - Return `new Blob([Buffer.concat(chunks)], { type: 'application/zip' })`
- - Removed now-unused `Archiver` type import
This is fully compatible with how `@metacall/protocol` passes the value to `FormData.append()`.

## CI Error (before fix)

```
X AxiosError: Request failed with status code 400
Error: Unexpected end of form
    at Multipart._final (node_modules/busboy/lib/types/multipart.js:588:17)
```