### PR TITLE
Improve ZIP handling and compatibility with upload pipeline

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,45 +110,69 @@ export const zip = async (
 	hide?: () => void,
 	ignorePatterns?: string[]
 ): Promise<Blob> => {
-	// Apply ignore patterns
 	files = filterFiles(files, ignorePatterns);
+
 	const archive = archiver('zip', {
 		zlib: { level: 9 }
 	});
 
-	if (progress) {
-		archive.on('progress', data =>
-			progress(
-				'Compressing and deploying...',
-				data.fs.processedBytes / data.fs.totalBytes
-			)
-		);
-	}
-
-	if (pulse) {
-		archive.on('entry', (entry: archiver.EntryData) => pulse(entry.name));
-	}
-
-	files = files.map(file => join(source, file));
-
-	for (const file of files) {
-		(await fs.stat(file)).isDirectory()
-			? archive.directory(file, basename(file))
-			: archive.file(file, { name: relative(source, file) });
-	}
-
-	// Collect chunks into a Blob. The archiver package extends readable-stream's
-	// Transform (not Node.js native stream.Readable), so passing the Archiver
-	// directly to protocol upload() would fail its instanceof Readable check.
 	const chunks: Buffer[] = [];
-	archive.on('data', (chunk: Buffer) => chunks.push(chunk));
 
-	await archive.finalize();
+	return new Promise<Blob>((resolve, reject) => {
+		if (progress) {
+			archive.on('progress', data => {
+				progress(
+					'Compressing and deploying...',
+					data.fs.processedBytes / data.fs.totalBytes
+				);
+			});
+		}
 
-	if (hide) hide();
+		if (pulse) {
+			archive.on('entry', (entry: archiver.EntryData) => {
+				pulse(entry.name);
+			});
+		}
 
-	return new Blob([Buffer.concat(chunks)], {
-		type: 'application/x-zip-compressed'
+		archive.on('data', (chunk: Buffer) => {
+			chunks.push(chunk);
+		});
+
+		archive.on('end', () => {
+			if (hide) {
+				archive.on('finish', () => hide());
+			}
+
+			resolve(
+				new Blob([Buffer.concat(chunks)], {
+					type: 'application/x-zip-compressed'
+				})
+			);
+		});
+
+		archive.on('error', reject);
+
+		void (async () => {
+			try {
+				const fullPaths = files.map(file => join(source, file));
+
+				for (const file of fullPaths) {
+					const stat = await fs.stat(file);
+
+					if (stat.isDirectory()) {
+						archive.directory(file, basename(file));
+					} else {
+						archive.file(file, {
+							name: relative(source, file)
+						});
+					}
+				}
+
+				await archive.finalize();
+			} catch (err) {
+				reject(err);
+			}
+		})();
 	});
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,62 +118,51 @@ export const zip = async (
 
 	const chunks: Buffer[] = [];
 
-	return new Promise<Blob>((resolve, reject) => {
-		if (progress) {
-			archive.on('progress', data => {
-				progress(
-					'Compressing and deploying...',
-					data.fs.processedBytes / data.fs.totalBytes
-				);
-			});
-		}
-
-		if (pulse) {
-			archive.on('entry', (entry: archiver.EntryData) => {
-				pulse(entry.name);
-			});
-		}
-
-		archive.on('data', (chunk: Buffer) => {
-			chunks.push(chunk);
+	if (progress) {
+		archive.on('progress', data => {
+			progress(
+				'Compressing and deploying...',
+				data.fs.processedBytes / data.fs.totalBytes
+			);
 		});
+	}
 
+	if (pulse) {
+		archive.on('entry', (entry: archiver.EntryData) => {
+			pulse(entry.name);
+		});
+	}
+
+	const dataPromise = new Promise<Blob>((resolve, reject) => {
+		archive.on('data', (chunk: Buffer) => chunks.push(chunk));
 		archive.on('end', () => {
 			if (hide) {
 				archive.on('finish', () => hide());
 			}
-
 			resolve(
 				new Blob([Buffer.concat(chunks)], {
 					type: 'application/x-zip-compressed'
 				})
 			);
 		});
-
 		archive.on('error', reject);
-
-		void (async () => {
-			try {
-				const fullPaths = files.map(file => join(source, file));
-
-				for (const file of fullPaths) {
-					const stat = await fs.stat(file);
-
-					if (stat.isDirectory()) {
-						archive.directory(file, basename(file));
-					} else {
-						archive.file(file, {
-							name: relative(source, file)
-						});
-					}
-				}
-
-				await archive.finalize();
-			} catch (err) {
-				reject(err);
-			}
-		})();
 	});
+
+	const fullPaths = files.map(file => join(source, file));
+
+	for (const file of fullPaths) {
+		const stat = await fs.stat(file);
+
+		if (stat.isDirectory()) {
+			archive.directory(file, basename(file));
+		} else {
+			archive.file(file, { name: relative(source, file) });
+		}
+	}
+
+	await archive.finalize();
+
+	return dataPromise;
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@
 */
 
 import { MetaCallJSON } from '@metacall/protocol/deployment';
-import archiver, { Archiver } from 'archiver';
+import archiver from 'archiver';
 import { parse } from 'dotenv';
 import { promises as fs } from 'fs';
 import { prompt } from 'inquirer';
@@ -109,7 +109,7 @@ export const zip = async (
 	pulse?: (name: string) => void,
 	hide?: () => void,
 	ignorePatterns?: string[]
-): Promise<Archiver> => {
+): Promise<Blob> => {
 	// Apply ignore patterns
 	files = filterFiles(files, ignorePatterns);
 	const archive = archiver('zip', {
@@ -137,13 +137,19 @@ export const zip = async (
 			: archive.file(file, { name: relative(source, file) });
 	}
 
-	if (hide) {
-		archive.on('finish', () => hide());
-	}
+	// Collect chunks into a Blob. The archiver package extends readable-stream's
+	// Transform (not Node.js native stream.Readable), so passing the Archiver
+	// directly to protocol upload() would fail its instanceof Readable check.
+	const chunks: Buffer[] = [];
+	archive.on('data', (chunk: Buffer) => chunks.push(chunk));
 
 	await archive.finalize();
 
-	return archive;
+	if (hide) hide();
+
+	return new Blob([Buffer.concat(chunks)], {
+		type: 'application/x-zip-compressed'
+	});
 };
 
 /**


### PR DESCRIPTION
Description
- This PR updates the ZIP utility to ensure compatibility with the deployment/upload pipeline by converting the archiver output into a Blob instead of returning the Archiver instance directly.

Changes I made:-
- Collect ZIP data chunks from archiver stream using data event
- Concatenate chunks into a single Buffer
- Return a Blob (application/x-zip-compressed) instead of Archiver
- Added explanatory comment about why Archiver cannot be used directly

Reason:-
The archiver package does not return a native Node.js Readable stream. Instead, it extends readable-stream's Transform, which causes issues when passing it to the deployment protocol (e.g., instanceof Readable checks fail).

This resulted in incompatibility with the upload mechanism.

By buffering the archive output and returning it as a Blob, we ensure:

  - Compatibility with the existing upload pipeline
  - Avoidance of stream-type mismatches
  - Consistent behavior across environments

Working GitHub workflow Link:- https://github.com/VanshikaSabharwal/faas/actions/runs/24439286633/job/71400355463