### PR TITLE
fix(cli): exit with non-zero code for unknown flags

### DIFF
--- a/src/cli/unknown.ts
+++ b/src/cli/unknown.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '../deploy';
 import { printHelp } from '../help';
 import args from './args';
 import { warn } from './messages';
@@ -10,6 +11,8 @@ export const handleUnknownArgs = (): void => {
 			', '
 		)} does not exist as a valid command.`;
 		warn(message);
+		printHelp(ErrorCode.UnknownFlag);
+		return;
 	}
 
 	printHelp();

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -29,12 +29,13 @@ import { filterFiles, getEnv, loadFilesToRun, zip } from './utils';
 
 export enum ErrorCode {
 	Ok = 0,
-	NotDirectoryRootPath = 1,
-	EmptyRootPath = 2,
-	NotFoundRootPath = 3,
-	AccountDisabled = 4,
-	DeployPackageFailed = 5,
-	DeployRepositoryFailed = 6
+	UnknownFlag = 1,
+	NotDirectoryRootPath = 2,
+	EmptyRootPath = 3,
+	NotFoundRootPath = 4,
+	AccountDisabled = 5,
+	DeployPackageFailed = 6,
+	DeployRepositoryFailed = 7
 }
 
 export const deployPackage = async (

--- a/src/help.ts
+++ b/src/help.ts
@@ -62,7 +62,7 @@ Examples:
 For more information, visit: https://github.com/metacall/deploy
 `;
 
-export const printHelp = (): void => {
+export const printHelp = (exitCode: ErrorCode = ErrorCode.Ok): void => {
 	console.log(helpText);
-	return process.exit(ErrorCode.Ok);
+	return process.exit(exitCode);
 };


### PR DESCRIPTION
## Description

The CLI was exiting with code 0 when unknown flags were passed, breaking CI pipelines and shell scripts that check exit codes.

Fixes #212

## Changes
- Add `UnknownFlag` error code to `ErrorCode` enum
- Add optional `exitCode` parameter to `printHelp()`
- Exit with `ErrorCode.UnknownFlag` when unknown flags are detected
- Keep exit code 0 for explicit `--help` flag

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)